### PR TITLE
Fix XML requests, which do not take a format=xml parameter.

### DIFF
--- a/src/Network/Lastfm/JSON.hs
+++ b/src/Network/Lastfm/JSON.hs
@@ -17,7 +17,7 @@ import Network.Lastfm.Error (LastfmError, disambiguate)
 json ∷ Format
 json = Format
         { errorParser = decode
-        , uriArgument = ("format","json")
+        , uriArgument = Just ("format","json")
         }
 
 

--- a/src/Network/Lastfm/XML.hs
+++ b/src/Network/Lastfm/XML.hs
@@ -18,7 +18,7 @@ import Network.Lastfm.Internal (Format(..))
 xml ∷ Format
 xml = Format
         { errorParser = xmlErrorParser
-        , uriArgument = ("format","xml")
+        , uriArgument = Nothing
         }
 
 


### PR DESCRIPTION
XML requests were not working because XML.hs specified ("format", "xml") as
uriArgument for Format, but Last.fm only accepts format=json (no format
parameter should be specified for XML output).

Previously, all XML requests were returning InvalidFormat because of this.
