### PR TITLE
Liblastfm doesn't compile with http-conduit < 1.9

### DIFF
--- a/liblastfm.cabal
+++ b/liblastfm.cabal
@@ -17,7 +17,7 @@ library
                  containers >= 0.5,
                  text,
                  cereal,
-                 http-conduit,
+                 http-conduit >= 1.9,
                  http-types,
                  pureMD5,
                  crypto-api,


### PR DESCRIPTION
Fails to compile with old versions of http-conduit.

```
src/Network/Lastfm/Response.hs:60:16:
    Couldn't match expected type `C.CookieJar -> e0'
                with actual type `C.HttpException'
    The function `C.StatusCodeException' is applied to three arguments,
   but its type `C.Status -> C.ResponseHeaders -> C.HttpException'
   has only two
```
